### PR TITLE
Rename onCloseOffcanvas prop to onCloseMenu

### DIFF
--- a/src/components/AuthNav/AuthNav.test.js
+++ b/src/components/AuthNav/AuthNav.test.js
@@ -9,11 +9,11 @@ jest.mock("../UserNav/UserNavSkeleton", () => () => (
 jest.mock("../GuestNav/GuestNavSkeleton", () => () => (
 	<div data-testid="guest-nav-skeleton" />
 ));
-jest.mock("../UserNav", () => ({ onCloseOffcanvas }) => (
-	<button type="button" data-testid="user-nav" onClick={onCloseOffcanvas} />
+jest.mock("../UserNav", () => ({ onCloseMenu }) => (
+	<button type="button" data-testid="user-nav" onClick={onCloseMenu} />
 ));
-jest.mock("../GuestNav", () => ({ onCloseOffcanvas }) => (
-	<button type="button" data-testid="guest-nav" onClick={onCloseOffcanvas} />
+jest.mock("../GuestNav", () => ({ onCloseMenu }) => (
+	<button type="button" data-testid="guest-nav" onClick={onCloseMenu} />
 ));
 
 /**
@@ -45,7 +45,7 @@ describe("AuthNav Component", () => {
 				<AuthNav
 					isAuthCheckComplete={false}
 					isLoggedIn={false}
-					onCloseOffcanvas={mockOnClose}
+					onCloseMenu={mockOnClose}
 				/>
 			);
 
@@ -60,7 +60,7 @@ describe("AuthNav Component", () => {
 				<AuthNav
 					isAuthCheckComplete={false}
 					isLoggedIn={false}
-					onCloseOffcanvas={mockOnClose}
+					onCloseMenu={mockOnClose}
 				/>
 			);
 
@@ -78,7 +78,7 @@ describe("AuthNav Component", () => {
 			<AuthNav
 				isAuthCheckComplete={true}
 				isLoggedIn={false}
-				onCloseOffcanvas={mockOnClose}
+				onCloseMenu={mockOnClose}
 			/>
 		);
 
@@ -98,7 +98,7 @@ describe("AuthNav Component", () => {
 			<AuthNav
 				isAuthCheckComplete={true}
 				isLoggedIn={true}
-				onCloseOffcanvas={mockOnClose}
+				onCloseMenu={mockOnClose}
 			/>
 		);
 

--- a/src/components/AuthNav/index.js
+++ b/src/components/AuthNav/index.js
@@ -21,9 +21,9 @@ const getInitialAuthState = () => {
  * @param {object} props
  * @param {boolean} props.isAuthCheckComplete - Si la comprobación de autenticación ha finalizado.
  * @param {boolean} props.isLoggedIn - Si el usuario está logueado.
- * @param {() => void} props.onCloseOffcanvas - Función para cerrar el menú Offcanvas al hacer clic en un enlace.
+ * @param {() => void} [props.onCloseMenu] - Función para cerrar el menú Offcanvas al hacer clic en un enlace.
  */
-const AuthNav = ({ isAuthCheckComplete, isLoggedIn, onCloseOffcanvas }) => {
+const AuthNav = ({ isAuthCheckComplete, isLoggedIn, onCloseMenu }) => {
 	// Para evitar el "salto" del esqueleto, no reaccionamos al estado de Redux que cambia
 	// durante la comprobación. En su lugar, tomamos una "pista" inicial de sessionStorage.
 	// Si hay un token, es muy probable que el usuario esté logueado, por lo que mostramos
@@ -37,9 +37,9 @@ const AuthNav = ({ isAuthCheckComplete, isLoggedIn, onCloseOffcanvas }) => {
 	}
 
 	return isLoggedIn ? (
-		<UserNav onCloseOffcanvas={onCloseOffcanvas} />
+		<UserNav onCloseMenu={onCloseMenu} />
 	) : (
-		<GuestNav onCloseOffcanvas={onCloseOffcanvas} />
+		<GuestNav onCloseMenu={onCloseMenu} />
 	);
 };
 

--- a/src/components/GuestNav/GuestNav.test.js
+++ b/src/components/GuestNav/GuestNav.test.js
@@ -11,7 +11,7 @@ describe("GuestNav Component", () => {
 		const handleClose = jest.fn();
 		render(
 			<BrowserRouter>
-				<GuestNav onCloseOffcanvas={handleClose} />
+				<GuestNav onCloseMenu={handleClose} />
 			</BrowserRouter>
 		);
 

--- a/src/components/GuestNav/index.js
+++ b/src/components/GuestNav/index.js
@@ -3,23 +3,25 @@ import { Link, NavLink } from "react-router-dom";
 import styles from "./GuestNav.module.css";
 
 /**
- * Muestra los enlaces de navegación para un usuario invitado (no logueado).
- * @param {{ onCloseOffcanvas: () => void }} props
+ * Muestra los enlaces de navegación para un usuario invitado (no logueado). Permite cerrar un menú contenedor (como un Offcanvas)
+ * si se proporciona la función `onCloseMenu`.
+ * @param {object} props - Las propiedades del componente.
+ * @param {() => void} [props.onCloseMenu] - Función para cerrar el menú contenedor en breakpoints pequeños.
  */
-const GuestNav = ({ onCloseOffcanvas }) => (
+const GuestNav = ({ onCloseMenu }) => (
 	<>
 		<Nav.Link
 			className={`${styles.navLink} ${styles.registerLink} me-lg-3`}
 			as={NavLink}
 			to="/registerPage"
-			onClick={onCloseOffcanvas}
+			onClick={onCloseMenu}
 		>
 			Regístrate
 		</Nav.Link>
 		<Nav.Link
 			as={Link}
 			to="/loginPage"
-			onClick={onCloseOffcanvas}
+			onClick={onCloseMenu}
 			className={`btn ${styles.navButton} loginLink`}
 		>
 			Inicia sesión

--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -43,11 +43,11 @@ function NavigationBarComponent({
 	 * Estado para controlar la visibilidad del componente Offcanvas (menú lateral).
 	 * @type {[boolean, React.Dispatch<React.SetStateAction<boolean>>]}
 	 */
-	const [showOffcanvas, setShowOffcanvas] = useState(false);
-	/** Cierra el menú Offcanvas. */
-	const handleCloseOffcanvas = () => setShowOffcanvas(false);
-	/** Abre el menú Offcanvas. */
-	const handleShowOffcanvas = () => setShowOffcanvas(true);
+	const [showMenu, setShowMenu] = useState(false);
+	/** Cierra el menú lateral (Offcanvas). */
+	const handleCloseMenu = () => setShowMenu(false);
+	/** Abre el menú lateral (Offcanvas). */
+	const handleShowMenu = () => setShowMenu(true);
 
 	/**
 	 * Variable que guarda el modo de tema actual (claro u oscuro) del estado de Redux. Se inicializa con la preferencia del
@@ -133,7 +133,7 @@ function NavigationBarComponent({
 					{/* Se eliminan las props 'as', 'to' y 'aria-label' para evitar un enlace anidado,
 					ya que el componente Logo ya es un enlace. Se mantiene 'onClick' para
 					que el menú lateral se cierre al pulsar el logo. */}
-					<Navbar.Brand onClick={handleCloseOffcanvas}>
+					<Navbar.Brand onClick={handleCloseMenu}>
 						<Logo />
 					</Navbar.Brand>
 				</div>
@@ -178,14 +178,14 @@ function NavigationBarComponent({
 						<AuthNav
 							isAuthCheckComplete={isAuthCheckComplete}
 							isLoggedIn={isLoggedIn}
-							onCloseOffcanvas={handleCloseOffcanvas}
+							onCloseMenu={handleCloseMenu}
 						/>
 					</Nav>
 					{/* Toggle Offcanvas (Hamburguesa) */}
 					<Navbar.Toggle
 						aria-controls="offcanvasNavbar" // prettier-ignore
 						label="Abrir menú de navegación" // prettier-ignore
-						onClick={handleShowOffcanvas} // prettier-ignore
+						onClick={handleShowMenu} // prettier-ignore
 						className={`d-lg-none ${styles.navbarToggler}`}
 					/>
 				</div>
@@ -204,8 +204,8 @@ function NavigationBarComponent({
 				{/* --- Final de contenedor de la derecha --- */}
 				{/* --- Componente Offcanvas --- */}
 				<Offcanvas
-					show={showOffcanvas}
-					onHide={handleCloseOffcanvas}
+					show={showMenu}
+					onHide={handleCloseMenu}
 					placement="end"
 					id="offcanvasNavbar"
 					scroll={true}
@@ -221,7 +221,7 @@ function NavigationBarComponent({
 							<AuthNav
 								isAuthCheckComplete={isAuthCheckComplete}
 								isLoggedIn={isLoggedIn}
-								onCloseOffcanvas={handleCloseOffcanvas}
+								onCloseMenu={handleCloseMenu}
 							/>
 						</Nav>
 					</Offcanvas.Body>

--- a/src/components/UserNav/UserNav.test.js
+++ b/src/components/UserNav/UserNav.test.js
@@ -40,13 +40,13 @@ describe("UserNav Component", () => {
 
 	/**
 	 * Prueba que el componente UserNav muestra correctamente los enlaces "Tu perfil" y "Cierra sesión" y que el clic en "Tu perfil"
-	 * invoca `onCloseOffcanvas`.
+	 * invoca `onCloseMenu`.
 	 */
 	test("muestra los enlaces 'Tu perfil' y 'Cierra sesión' y maneja los clics", () => {
 		render(
 			<Provider store={store}>
 				<BrowserRouter>
-					<UserNav onCloseOffcanvas={handleClose} />
+					<UserNav onCloseMenu={handleClose} />
 				</BrowserRouter>
 			</Provider>
 		);
@@ -77,7 +77,7 @@ describe("UserNav Component", () => {
 		render(
 			<Provider store={store}>
 				<BrowserRouter>
-					<UserNav onCloseOffcanvas={handleClose} />
+					<UserNav onCloseMenu={handleClose} />
 				</BrowserRouter>
 			</Provider>
 		);
@@ -117,7 +117,7 @@ describe("UserNav Component", () => {
 		render(
 			<Provider store={store}>
 				<BrowserRouter>
-					<UserNav onCloseOffcanvas={handleClose} />
+					<UserNav onCloseMenu={handleClose} />
 				</BrowserRouter>
 			</Provider>
 		);


### PR DESCRIPTION
Refactored the prop name from onCloseOffcanvas to onCloseMenu across AuthNav, GuestNav, UserNav, and NavigationBar components and their tests for clarity and consistency. This improves readability and better reflects the purpose of the prop, which is to close the navigation menu.