### PR TITLE
Refactor/improving error message alert security

### DIFF
--- a/src/components/ErrorMessageAlert/ErrorMessageAlert.js
+++ b/src/components/ErrorMessageAlert/ErrorMessageAlert.js
@@ -12,10 +12,16 @@ import { Alert } from "react-bootstrap";
  * @returns {React.ReactElement} El componente de alerta de error.
  */
 function ErrorMessageAlert({ message, onClose }) {
+	// Verificación de seguridad: Nos aseguramos de que el mensaje sea una cadena de texto
+	// para prevenir vulnerabilidades de Cross-Site Scripting (XSS). Si se recibe algo
+	// que no es un string, se mostrará un mensaje de error genérico y seguro.
+	const content =
+		typeof message === "string" ? message : "Ha ocurrido un error inesperado.";
+
 	return (
 		<Alert variant="danger" onClose={onClose} dismissible>
 			<Alert.Heading as="h2">Error</Alert.Heading>
-			{message}
+			{content}
 		</Alert>
 	);
 }

--- a/src/components/ErrorMessageAlert/ErrorMessageAlert.test.js
+++ b/src/components/ErrorMessageAlert/ErrorMessageAlert.test.js
@@ -40,4 +40,22 @@ describe("ErrorMessageAlert Component", () => {
 		// Verifica que la función mock `onClose` fue llamada exactamente una vez.
 		expect(mockOnClose).toHaveBeenCalledTimes(1);
 	});
+
+	test("muestra un mensaje genérico y seguro si la prop 'message' no es un string", () => {
+		// Un ejemplo de un elemento que no es un string y podría ser malicioso.
+		const maliciousElement = <span>Contenido malicioso</span>;
+
+		render(
+			// @ts-ignore: Se pasa un elemento a propósito para probar la robustez del componente.
+			<ErrorMessageAlert message={maliciousElement} onClose={mockOnClose} />
+		);
+
+		// VERIFICAR: El contenido malicioso NO debe renderizarse.
+		expect(screen.queryByText("Contenido malicioso")).not.toBeInTheDocument();
+
+		// VERIFICAR: Se debe mostrar el mensaje de respaldo seguro.
+		expect(
+			screen.getByText("Ha ocurrido un error inesperado.")
+		).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
1. Adds a type check to ensure the error message is a string before rendering, displaying a generic error if not. This improves security by preventing potential Cross-Site Scripting vulnerabilities.
2. Added a test to ensure ErrorMessageAlert displays a safe fallback message when the 'message' prop is not a string, preventing rendering of potentially malicious content.